### PR TITLE
add msodbc driver to `run_tox` for Synapse & Fabric tests

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -309,6 +309,34 @@ jobs:
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
 
+            - name: "Install Microsoft ODBC Driver"
+              run: |
+                  # source: https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server
+                  if ! [[ "18.04 20.04 22.04 23.04 24.04" == *"$(lsb_release -rs)"* ]];
+                  then
+                      echo "Ubuntu $(lsb_release -rs) is not currently supported.";
+                      exit;
+                  fi
+
+                  # Add the signature to trust the Microsoft repo
+                  # For Ubuntu versions < 24.04 
+                  curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+                  # For Ubuntu versions >= 24.04
+                  curl https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+
+                  # Add repo to apt sources
+                  curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+
+                  # Install the driver
+                  sudo apt-get update
+                  sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+                  # optional: for bcp and sqlcmd
+                  sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18
+                  echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
+                  source ~/.bashrc
+                  # optional: for unixODBC development headers
+                  sudo apt-get install -y unixodbc-dev
+
             - name: "Install ${{ matrix.adapter }}"
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -309,7 +309,8 @@ jobs:
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
 
-            - name: "Install Microsoft ODBC Driver"
+            - name: "Install Microsoft ODBC Driver for Fabric and Synapse"
+              if: ${{ matrix.adapter == 'synapse' || matrix.adapter == 'fabric' }}
               run: |
                   # source: https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server
                   if ! [[ "18.04 20.04 22.04 23.04 24.04" == *"$(lsb_release -rs)"* ]];


### PR DESCRIPTION
resolves #9

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

I added the steps to install the driver. Right now this driver will be instaleed for all invocations which will slow all tests down. A better idea might be to either:
- use a pre-built DOcker image of ubuntu with msodbc already installed
- make the install step only happen for Fabric and Synapse

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-package-testing/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
