### PR TITLE
Pin GitHub Actions to specific SHAs (4 actions in 1 files)

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -243,10 +243,10 @@ jobs:
             adapters: ${{ steps.supported-adapters.outputs.adapters }}
         steps:
             - name: "Checkout ${{ github.event.repository }}"
-              uses: actions/checkout@v4
+              uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
             - name: "Set up Python ${{ env.PYTHON_VERSION }}"
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
 
@@ -302,10 +302,10 @@ jobs:
 
         steps:
             - name: "Checkout ${{ github.event.repository }} "
-              uses: actions/checkout@v4
+              uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
 
             - name: "Set up Python ${{ env.PYTHON_VERSION }}"
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 4

### 📝 Changes by file

#### `.github/workflows/run_tox.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5`
- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5`

