### PR TITLE
feat: add Fusion engine workflow and pull_request_target support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 # **what?**
-# Run tests for <this package> against supported adapters
+# Example CI workflow for a dbt package using the reusable Core and Fusion workflows.
+# Copy and adapt this for your own package.
 
 # **why?**
 # To ensure that <this package> works as expected with all supported adapters
 
 # **when?**
-# On every PR, and every push to main and when manually triggered
+# On every PR (including forks), every push to main, and when manually triggered
 
 name: Package Integration Tests
 
@@ -13,17 +14,25 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
     workflow_dispatch:
 
 jobs:
-  run-tests:
-      uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@main
-      # Note: only include the inputs below for the adapters you are testing against.
-      # All inputs are optional and postgres has default values.
+  # --- dbt Core tests ---
+  core-tests:
+      uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@v2
       with:
-        # Postgres is defaulted since it runs right in the container.
-        # No need to pass postgres vars in.
+        # Optional: specify adapters explicitly, otherwise reads from supported_adapters.env
+        adapters: "snowflake,bigquery,redshift,databricks"
+        # For pull_request_target: require environment approval for fork PRs
+        environment: >-
+          ${{ github.event_name == 'pull_request_target'
+              && github.event.pull_request.head.repo.full_name != github.repository
+              && 'cloud-tests' || '' }}
+        # For pull_request_target: checkout the PR head, not the base branch
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+        # Note: only include the inputs below for the adapters you are testing against.
+        # All inputs are optional and postgres has default values.
         # redshift
         REDSHIFT_HOST: ${{ vars.REDSHIFT_HOST }}
         REDSHIFT_USER: ${{ vars.REDSHIFT_USER }}
@@ -33,7 +42,7 @@ jobs:
         # bigquery
         BIGQUERY_PROJECT: ${{ vars.BIGQUERY_PROJECT }}
         BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
-         # snowflake
+        # snowflake
         SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
         SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
         SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
@@ -93,3 +102,39 @@ jobs:
         DBT_ENV_SECRET_SYNAPSE_CLIENT_SECRET: ${{ secrets.DBT_ENV_SECRET_SYNAPSE_CLIENT_SECRET }}
         DBT_ENV_SECRET_ATHENA_AWS_ACCESS_KEY_ID: ${{ secrets.DBT_ENV_SECRET_ATHENA_AWS_ACCESS_KEY_ID }}
         DBT_ENV_SECRET_ATHENA_AWS_SECRET_ACCESS_KEY: ${{ secrets.DBT_ENV_SECRET_ATHENA_AWS_SECRET_ACCESS_KEY }}
+
+  # --- dbt Fusion tests ---
+  fusion-tests:
+      uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox_fusion.yml@v2
+      with:
+        adapters: "snowflake,bigquery,redshift,databricks"
+        environment: >-
+          ${{ github.event_name == 'pull_request_target'
+              && github.event.pull_request.head.repo.full_name != github.repository
+              && 'cloud-tests' || '' }}
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+        # redshift
+        REDSHIFT_HOST: ${{ vars.REDSHIFT_HOST }}
+        REDSHIFT_USER: ${{ vars.REDSHIFT_USER }}
+        REDSHIFT_DATABASE: ${{ vars.REDSHIFT_DATABASE }}
+        REDSHIFT_SCHEMA: "fusion_integration_tests_redshift_${{ github.run_number }}"
+        REDSHIFT_PORT: ${{ vars.REDSHIFT_PORT }}
+        # bigquery
+        BIGQUERY_PROJECT: ${{ vars.BIGQUERY_PROJECT }}
+        BIGQUERY_SCHEMA: "fusion_integration_tests_bigquery_${{ github.run_number }}"
+        # snowflake
+        SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
+        SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
+        SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
+        SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
+        SNOWFLAKE_SCHEMA: "fusion_integration_tests_snowflake_${{ github.run_number }}"
+        # databricks
+        DATABRICKS_SCHEMA: "fusion_integration_tests_databricks_${{ github.run_number }}"
+        DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+        DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
+      secrets:
+        DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.DBT_ENV_SECRET_REDSHIFT_PASS }}
+        BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+        SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+        DBT_ENV_SECRET_SNOWFLAKE_PASS: ${{ secrets.DBT_ENV_SECRET_SNOWFLAKE_PASS }}
+        DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
     pull_request_target:
     workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # --- dbt Core tests ---
   core-tests:

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -365,7 +365,9 @@ jobs:
             - name: "Install ${{ matrix.adapter }}"
               run: |
                   python -m pip install --upgrade pip
-                  pip install dbt-${{ matrix.adapter }}
+                  pip install "dbt-$ADAPTER"
+              env:
+                  ADAPTER: ${{ matrix.adapter }}
 
             - name: "Install tox"
               run: |
@@ -377,7 +379,6 @@ jobs:
                   tox -e "dbt_integration_$ADAPTER"
               env:
                 ADAPTER: ${{ matrix.adapter }}
-              env:
                 # postgres
                 POSTGRES_HOST: ${{ inputs.POSTGRES_HOST }}
                 POSTGRES_USER: ${{ inputs.POSTGRES_USER }}

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -251,7 +251,7 @@ on:
                 required: false
 
 env:
-    PYTHON_VERSION: "3.13"
+    PYTHON_VERSION: "3.11"
 
 jobs:
     determine-supported-adapters:

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -283,15 +283,20 @@ jobs:
               id: supported-adapters
               run: |
                   # Convert to JSON array and output
-                  supported_adapters=$(echo "${{ steps.list-adapters.outputs.test_adapters }}" | jq -Rc 'split(",")')
+                  supported_adapters=$(echo "$TEST_ADAPTERS" | jq -Rc 'split(",")')
                   echo $supported_adapters
                   echo "adapters=$supported_adapters" >> $GITHUB_OUTPUT
+              env:
+                  TEST_ADAPTERS: ${{ steps.list-adapters.outputs.test_adapters }}
 
-            - name: "[ANNOTATION] ${{ github.event.repository.name }} - Testing ${{ steps.supported-adapters.outputs.adapters }}"
+            - name: "[ANNOTATION] - Testing adapters"
               run: |
-                  title="${{ github.event.repository.name }} - adapters to test"
-                  message="The workflow will run tests for the following adapters: ${{ steps.supported-adapters.outputs.adapters }}"
+                  title="$REPO_NAME - adapters to test"
+                  message="The workflow will run tests for the following adapters: $SUPPORTED_ADAPTERS"
                   echo "::notice $title::$message"
+              env:
+                  REPO_NAME: ${{ github.event.repository.name }}
+                  SUPPORTED_ADAPTERS: ${{ steps.supported-adapters.outputs.adapters }}
 
     run-tests:
         runs-on: ubuntu-latest
@@ -369,7 +374,9 @@ jobs:
 
             - name: "Run integration tests with tox on ${{ matrix.adapter }}"
               run: |
-                  tox -e dbt_integration_${{ matrix.adapter }}
+                  tox -e "dbt_integration_$ADAPTER"
+              env:
+                ADAPTER: ${{ matrix.adapter }}
               env:
                 # postgres
                 POSTGRES_HOST: ${{ inputs.POSTGRES_HOST }}

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -15,6 +15,23 @@ name: Package Integration Tests
 on:
     workflow_call:
         inputs:
+            # -- shared inputs --
+            adapters:
+                description: "Comma-separated list of adapters to test (e.g. 'snowflake,bigquery'). Falls back to supported_adapters.env if not provided."
+                required: false
+                type: string
+                default: ""
+            environment:
+                description: "GitHub Environment name for job protection (e.g. 'cloud-tests'). Leave empty for no environment gating."
+                required: false
+                type: string
+                default: ""
+            ref:
+                description: "Git ref to checkout. Pass github.event.pull_request.head.sha for pull_request_target workflows."
+                required: false
+                type: string
+                default: ""
+            # -- adapter-specific inputs --
             # postgres
             # postgres vars are all defaulted so that they are not required to be passed
             # in since the postgres tests will run inside the container with a local instance
@@ -234,7 +251,7 @@ on:
                 required: false
 
 env:
-    PYTHON_VERSION: "3.11"
+    PYTHON_VERSION: "3.13"
 
 jobs:
     determine-supported-adapters:
@@ -244,24 +261,23 @@ jobs:
         steps:
             - name: "Checkout ${{ github.event.repository }}"
               uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
-
-            - name: "Set up Python ${{ env.PYTHON_VERSION }}"
-              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
               with:
-                  python-version: ${{ env.PYTHON_VERSION }}
-
-            - name: "Install tox"
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install tox
+                  ref: ${{ inputs.ref || github.ref }}
 
             - name: "Get list of supported adapters"
               id: list-adapters
               run: |
-                # github adds a pip freeze and a new line we need to strip out
-                source supported_adapters.env
-                echo $SUPPORTED_ADAPTERS
-                echo "test_adapters=$SUPPORTED_ADAPTERS" >> $GITHUB_OUTPUT
+                if [ -n "$INPUT_ADAPTERS" ]; then
+                  echo "Using adapters from workflow input: $INPUT_ADAPTERS"
+                  echo "test_adapters=$INPUT_ADAPTERS" >> $GITHUB_OUTPUT
+                else
+                  echo "Using adapters from supported_adapters.env"
+                  source supported_adapters.env
+                  echo $SUPPORTED_ADAPTERS
+                  echo "test_adapters=$SUPPORTED_ADAPTERS" >> $GITHUB_OUTPUT
+                fi
+              env:
+                INPUT_ADAPTERS: ${{ inputs.adapters }}
 
             - name: "Format adapter list for use as the matrix"
               id: supported-adapters
@@ -280,6 +296,7 @@ jobs:
     run-tests:
         runs-on: ubuntu-latest
         needs: [determine-supported-adapters]
+        environment: ${{ inputs.environment || null }}
         services:
             postgres:
                 image: postgres
@@ -303,6 +320,8 @@ jobs:
         steps:
             - name: "Checkout ${{ github.event.repository }} "
               uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
+              with:
+                  ref: ${{ inputs.ref || github.ref }}
 
             - name: "Set up Python ${{ env.PYTHON_VERSION }}"
               uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5

--- a/.github/workflows/run_tox_fusion.yml
+++ b/.github/workflows/run_tox_fusion.yml
@@ -109,7 +109,7 @@ jobs:
             - name: "Checkout ${{ github.event.repository }}"
               uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
               with:
-                  ref: ${{ inputs.ref || github.ref }}
+                  ref: ${{ github.ref }}
 
             - name: "Get list of supported adapters"
               id: list-adapters
@@ -130,15 +130,20 @@ jobs:
               id: supported-adapters
               run: |
                   # Convert to JSON array and output
-                  supported_adapters=$(echo "${{ steps.list-adapters.outputs.test_adapters }}" | jq -Rc 'split(",")')
+                  supported_adapters=$(echo "$TEST_ADAPTERS" | jq -Rc 'split(",")')
                   echo $supported_adapters
                   echo "adapters=$supported_adapters" >> $GITHUB_OUTPUT
+              env:
+                  TEST_ADAPTERS: ${{ steps.list-adapters.outputs.test_adapters }}
 
-            - name: "[ANNOTATION] ${{ github.event.repository.name }} - Fusion testing ${{ steps.supported-adapters.outputs.adapters }}"
+            - name: "[ANNOTATION] - Fusion testing adapters"
               run: |
-                  title="${{ github.event.repository.name }} - Fusion adapters to test"
-                  message="The workflow will run Fusion tests for the following adapters: ${{ steps.supported-adapters.outputs.adapters }}"
+                  title="$REPO_NAME - Fusion adapters to test"
+                  message="The workflow will run Fusion tests for the following adapters: $SUPPORTED_ADAPTERS"
                   echo "::notice $title::$message"
+              env:
+                  REPO_NAME: ${{ github.event.repository.name }}
+                  SUPPORTED_ADAPTERS: ${{ steps.supported-adapters.outputs.adapters }}
 
     run-tests:
         runs-on: ubuntu-latest
@@ -176,7 +181,9 @@ jobs:
 
             - name: "Run Fusion integration tests with tox on ${{ matrix.adapter }}"
               run: |
-                  tox -e dbt_integration_fusion_${{ matrix.adapter }}
+                  tox -e "dbt_integration_fusion_$ADAPTER"
+              env:
+                ADAPTER: ${{ matrix.adapter }}
               env:
                 # redshift
                 REDSHIFT_HOST: ${{ inputs.REDSHIFT_HOST }}

--- a/.github/workflows/run_tox_fusion.yml
+++ b/.github/workflows/run_tox_fusion.yml
@@ -109,7 +109,7 @@ jobs:
             - name: "Checkout ${{ github.event.repository }}"
               uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
               with:
-                  ref: ${{ github.ref }}
+                  ref: refs/heads/main
 
             - name: "Get list of supported adapters"
               id: list-adapters

--- a/.github/workflows/run_tox_fusion.yml
+++ b/.github/workflows/run_tox_fusion.yml
@@ -184,7 +184,6 @@ jobs:
                   tox -e "dbt_integration_fusion_$ADAPTER"
               env:
                 ADAPTER: ${{ matrix.adapter }}
-              env:
                 # redshift
                 REDSHIFT_HOST: ${{ inputs.REDSHIFT_HOST }}
                 REDSHIFT_USER: ${{ inputs.REDSHIFT_USER }}

--- a/.github/workflows/run_tox_fusion.yml
+++ b/.github/workflows/run_tox_fusion.yml
@@ -1,0 +1,204 @@
+# **what?**
+# Run tests for packages against supported adapters using dbt Fusion
+#
+# **why?**
+# To ensure that packages work as expected with dbt Fusion across supported adapters
+
+# **when?**
+# On workflow call
+# This is a workflow meant to be called by many different packages to run Fusion integration tests.
+# Any changes should be backwards compatible with all packages that call this workflow.
+
+
+name: Fusion Integration Tests
+
+on:
+    workflow_call:
+        inputs:
+            # -- shared inputs --
+            adapters:
+                description: "Comma-separated list of adapters to test (e.g. 'snowflake,bigquery'). Falls back to supported_adapters.env if not provided."
+                required: false
+                type: string
+                default: ""
+            environment:
+                description: "GitHub Environment name for job protection (e.g. 'cloud-tests'). Leave empty for no environment gating."
+                required: false
+                type: string
+                default: ""
+            ref:
+                description: "Git ref to checkout. Pass github.event.pull_request.head.sha for pull_request_target workflows."
+                required: false
+                type: string
+                default: ""
+            # -- adapter-specific inputs --
+            # redshift
+            REDSHIFT_HOST:
+                required: false
+                type: string
+            REDSHIFT_USER:
+                required: false
+                type: string
+            REDSHIFT_DATABASE:
+                required: false
+                type: string
+            REDSHIFT_SCHEMA:
+                required: false
+                type: string
+            REDSHIFT_PORT:
+                required: false
+                type: string
+            # bigquery
+            BIGQUERY_PROJECT:
+                required: false
+                type: string
+            BIGQUERY_SCHEMA:
+                required: false
+                type: string
+            # snowflake
+            SNOWFLAKE_USER:
+                required: false
+                type: string
+            SNOWFLAKE_ROLE:
+                required: false
+                type: string
+            SNOWFLAKE_DATABASE:
+                required: false
+                type: string
+            SNOWFLAKE_WAREHOUSE:
+                required: false
+                type: string
+            SNOWFLAKE_SCHEMA:
+                required: false
+                type: string
+            # databricks
+            DATABRICKS_SCHEMA:
+                required: false
+                type: string
+            DATABRICKS_HOST:
+                required: false
+                type: string
+            DATABRICKS_HTTP_PATH:
+                required: false
+                type: string
+        secrets:
+            # redshift
+            DBT_ENV_SECRET_REDSHIFT_PASS:
+                required: false
+            # bigquery
+            BIGQUERY_KEYFILE_JSON:
+                required: false
+            # snowflake
+            SNOWFLAKE_ACCOUNT:
+                required: false
+            DBT_ENV_SECRET_SNOWFLAKE_PASS:
+                required: false
+            # databricks
+            DBT_ENV_SECRET_DATABRICKS_TOKEN:
+                required: false
+
+env:
+    PYTHON_VERSION: "3.13"
+
+jobs:
+    determine-supported-adapters:
+        runs-on: ubuntu-latest
+        outputs:
+            adapters: ${{ steps.supported-adapters.outputs.adapters }}
+        steps:
+            - name: "Checkout ${{ github.event.repository }}"
+              uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
+              with:
+                  ref: ${{ inputs.ref || github.ref }}
+
+            - name: "Get list of supported adapters"
+              id: list-adapters
+              run: |
+                if [ -n "$INPUT_ADAPTERS" ]; then
+                  echo "Using adapters from workflow input: $INPUT_ADAPTERS"
+                  echo "test_adapters=$INPUT_ADAPTERS" >> $GITHUB_OUTPUT
+                else
+                  echo "Using adapters from supported_adapters.env"
+                  source supported_adapters.env
+                  echo $SUPPORTED_ADAPTERS
+                  echo "test_adapters=$SUPPORTED_ADAPTERS" >> $GITHUB_OUTPUT
+                fi
+              env:
+                INPUT_ADAPTERS: ${{ inputs.adapters }}
+
+            - name: "Format adapter list for use as the matrix"
+              id: supported-adapters
+              run: |
+                  # Convert to JSON array and output
+                  supported_adapters=$(echo "${{ steps.list-adapters.outputs.test_adapters }}" | jq -Rc 'split(",")')
+                  echo $supported_adapters
+                  echo "adapters=$supported_adapters" >> $GITHUB_OUTPUT
+
+            - name: "[ANNOTATION] ${{ github.event.repository.name }} - Fusion testing ${{ steps.supported-adapters.outputs.adapters }}"
+              run: |
+                  title="${{ github.event.repository.name }} - Fusion adapters to test"
+                  message="The workflow will run Fusion tests for the following adapters: ${{ steps.supported-adapters.outputs.adapters }}"
+                  echo "::notice $title::$message"
+
+    run-tests:
+        runs-on: ubuntu-latest
+        needs: [determine-supported-adapters]
+        environment: ${{ inputs.environment || null }}
+        strategy:
+            fail-fast: false
+            matrix:
+                adapter: ${{fromJson(needs.determine-supported-adapters.outputs.adapters)}}
+
+        steps:
+            - name: "Checkout ${{ github.event.repository }}"
+              uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
+              with:
+                  ref: ${{ inputs.ref || github.ref }}
+
+            - name: "Set up Python ${{ env.PYTHON_VERSION }}"
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # actions/setup-python@v5
+              with:
+                  python-version: ${{ env.PYTHON_VERSION }}
+
+            - name: "Install dbt Fusion"
+              run: |
+                  curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh
+                  echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+            - name: "Verify Fusion installation"
+              run: |
+                  dbt --version
+
+            - name: "Install tox"
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install tox
+
+            - name: "Run Fusion integration tests with tox on ${{ matrix.adapter }}"
+              run: |
+                  tox -e dbt_integration_fusion_${{ matrix.adapter }}
+              env:
+                # redshift
+                REDSHIFT_HOST: ${{ inputs.REDSHIFT_HOST }}
+                REDSHIFT_USER: ${{ inputs.REDSHIFT_USER }}
+                DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.DBT_ENV_SECRET_REDSHIFT_PASS }}
+                REDSHIFT_DATABASE: ${{ inputs.REDSHIFT_DATABASE }}
+                REDSHIFT_SCHEMA: ${{ inputs.REDSHIFT_SCHEMA }}
+                REDSHIFT_PORT: ${{ inputs.REDSHIFT_PORT }}
+                # bigquery
+                BIGQUERY_PROJECT: ${{ inputs.BIGQUERY_PROJECT }}
+                BIGQUERY_KEYFILE_JSON: ${{ secrets.BIGQUERY_KEYFILE_JSON }}
+                BIGQUERY_SCHEMA: ${{ inputs.BIGQUERY_SCHEMA }}
+                # snowflake
+                SNOWFLAKE_USER: ${{ inputs.SNOWFLAKE_USER }}
+                SNOWFLAKE_ROLE: ${{ inputs.SNOWFLAKE_ROLE }}
+                SNOWFLAKE_DATABASE: ${{ inputs.SNOWFLAKE_DATABASE }}
+                SNOWFLAKE_WAREHOUSE: ${{ inputs.SNOWFLAKE_WAREHOUSE }}
+                SNOWFLAKE_SCHEMA: ${{ inputs.SNOWFLAKE_SCHEMA }}
+                SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+                DBT_ENV_SECRET_SNOWFLAKE_PASS: ${{ secrets.DBT_ENV_SECRET_SNOWFLAKE_PASS }}
+                # databricks
+                DATABRICKS_SCHEMA: ${{ inputs.DATABRICKS_SCHEMA }}
+                DATABRICKS_HOST: ${{ inputs.DATABRICKS_HOST }}
+                DATABRICKS_HTTP_PATH: ${{ inputs.DATABRICKS_HTTP_PATH }}
+                DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DBT_ENV_SECRET_DATABRICKS_TOKEN }}

--- a/.github/workflows/run_tox_fusion.yml
+++ b/.github/workflows/run_tox_fusion.yml
@@ -98,7 +98,7 @@ on:
                 required: false
 
 env:
-    PYTHON_VERSION: "3.13"
+    PYTHON_VERSION: "3.11"
 
 jobs:
     determine-supported-adapters:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,148 @@
 ## Understanding dbt-package-testing
 
-This is an example of how to test packages. For more info on how to test packages, refer to:
-- [Integration tests](https://docs.getdbt.com/guides/building-packages?step=4) for new packages maintainers.
-- [Test package with Fusion](https://docs.getdbt.com/guides/fusion-package-compat?step=5#test-package-with-fusion) to test your package with Fusion to ensure compatibility.
+This repo provides reusable GitHub Actions workflows for testing dbt packages against supported adapters:
+
+- **`run_tox.yml`** — runs integration tests using dbt Core
+- **`run_tox_fusion.yml`** — runs integration tests using the dbt Fusion engine
+
+For more info on how to test packages, refer to:
+- [Integration tests](https://docs.getdbt.com/guides/building-packages?step=4) for new package maintainers.
+- [Test package with Fusion](https://docs.getdbt.com/guides/fusion-package-compat?step=5#test-package-with-fusion) to test your package with the dbt Fusion engine to ensure compatibility.
+
+## Setup
+
+To use these workflows, your package repo needs a few things: a dbt project for integration tests, a `profiles.yml` wired to environment variables, a `tox.ini` to run the tests, and a caller workflow.
+
+### 1. Integration test project
+
+Your repo needs an `integration_tests/` directory containing a dbt project with:
+
+- `dbt_project.yml`
+- `profiles.yml` — defines a target for each adapter, using `env_var()` to read credentials from the environment. You can copy [`integration_tests/profiles.yml`](integration_tests/profiles.yml) from this repo as a starting point — it includes targets for all supported adapters.
+
+For example, a Snowflake target in `profiles.yml`:
+
+```yaml
+integration_tests:
+  target: snowflake
+  outputs:
+    snowflake:
+      type: "snowflake"
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      password: "{{ env_var('DBT_ENV_SECRET_SNOWFLAKE_PASS') }}"
+      role: "{{ env_var('SNOWFLAKE_ROLE') }}"
+      database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
+      schema: "{{ env_var('SNOWFLAKE_SCHEMA') }}"
+      threads: 10
+```
+
+### 2. `tox.ini`
+
+Your package needs a `tox.ini` at the repo root. The workflows run `tox -e dbt_integration_<adapter>` (Core) or `tox -e dbt_integration_fusion_<adapter>` (Fusion engine), so the environment names must follow this convention.
+
+The `[testenv]` section must include a `passenv` list with all the environment variables your adapters need. Tox isolates the environment by default, so without `passenv` the credentials set by the workflow won't reach dbt. See the [`tox.ini`](tox.ini) in this repo for a complete example.
+
+**For dbt Core**, create `[testenv:dbt_integration_<adapter>]` sections:
+
+```ini
+[testenv]
+passenv =
+    SNOWFLAKE_ACCOUNT
+    SNOWFLAKE_USER
+    DBT_ENV_SECRET_SNOWFLAKE_PASS
+    SNOWFLAKE_ROLE
+    SNOWFLAKE_DATABASE
+    SNOWFLAKE_WAREHOUSE
+    SNOWFLAKE_SCHEMA
+    # ... add all env vars for your adapters
+
+[testenv:dbt_integration_snowflake]
+changedir = integration_tests
+allowlist_externals =
+    dbt
+skip_install = true
+commands =
+    dbt deps --target snowflake
+    dbt build -x --target snowflake --full-refresh
+```
+
+**For the dbt Fusion engine**, create `[testenv:dbt_integration_fusion_<adapter>]` sections:
+
+```ini
+[testenv:dbt_integration_fusion_snowflake]
+changedir = integration_tests
+allowlist_externals =
+    dbt
+skip_install = true
+commands =
+    dbt deps --target snowflake
+    dbt build -x --target snowflake --full-refresh
+```
+
+**About `--static-analysis=off`:** By default, you should _not_ set this flag — the dbt Fusion engine's static analysis provides valuable validation. However, you may need to add `--static-analysis=off` to your commands if:
+
+- Your integration tests don't have all sources available at parse time
+- Your package uses SQL functions or patterns not yet supported by the dbt Fusion engine's static analyzer
+
+If you do need it, add it to the dbt commands in your tox environment:
+
+```ini
+commands =
+    dbt deps --target snowflake
+    dbt build -x --target snowflake --full-refresh --static-analysis=off
+```
+
+### 3. Adapter list
+
+The workflows need to know which adapters to test. You can either:
+
+- **Pass the `adapters` input** explicitly in your workflow call (e.g. `adapters: "snowflake,bigquery"`) — recommended
+- **Create a `supported_adapters.env` file** at the repo root as a fallback:
+  ```
+  SUPPORTED_ADAPTERS=snowflake,bigquery,redshift,databricks
+  ```
+
+### 4. GitHub secrets and variables
+
+The workflows pass credentials to dbt via environment variables. You need to configure these in your GitHub repo settings under **Settings > Secrets and variables > Actions**:
+
+- **Secrets** — for sensitive values like passwords and tokens (e.g. `SNOWFLAKE_ACCOUNT`, `DBT_ENV_SECRET_SNOWFLAKE_PASS`, `BIGQUERY_KEYFILE_JSON`)
+- **Variables** — for non-sensitive values like hostnames and roles (e.g. `SNOWFLAKE_USER`, `SNOWFLAKE_ROLE`, `SNOWFLAKE_DATABASE`)
+
+The names must match what your `profiles.yml` expects via `env_var()` and what you pass as inputs/secrets in the caller workflow. See the [`ci.yml`](.github/workflows/ci.yml) example for the full list of inputs and secrets each workflow accepts.
+
+### 5. Caller workflow
+
+Create a `.github/workflows/ci.yml` in your package repo that calls the reusable workflows. See [`ci.yml`](.github/workflows/ci.yml) in this repo for a complete example.
+
+**Key inputs:**
+
+| Input | Description |
+|-------|-------------|
+| `adapters` | Comma-separated adapter list (falls back to `supported_adapters.env`) |
+| `environment` | GitHub Environment name for fork PR protection (see below) |
+| `ref` | Git ref to checkout — required for `pull_request_target` callers |
+
+All adapter-specific inputs (e.g. `SNOWFLAKE_USER`, `BIGQUERY_PROJECT`) and secrets (e.g. `SNOWFLAKE_ACCOUNT`, `DBT_ENV_SECRET_SNOWFLAKE_PASS`) are optional — only include the ones for adapters you're testing.
+
+### 6. Fork PR protection (optional)
+
+If your workflow uses `pull_request_target` to run CI on fork PRs (which need access to secrets), you can gate execution behind a GitHub Environment:
+
+1. Create a GitHub Environment in your repo settings (e.g. `cloud-tests`) with required reviewers.
+2. Pass the environment name conditionally in your workflow call:
+
+```yaml
+environment: >-
+  ${{ github.event_name == 'pull_request_target'
+      && github.event.pull_request.head.repo.full_name != github.repository
+      && 'cloud-tests' || '' }}
+ref: ${{ github.event.pull_request.head.sha || '' }}
+```
+
+This requires a maintainer to approve the workflow run before fork PRs get access to secrets.
 
 ## Reporting bugs and contributing code
 

--- a/docs/plans/2026-03-09-core-fusion-workflows-design.md
+++ b/docs/plans/2026-03-09-core-fusion-workflows-design.md
@@ -1,0 +1,107 @@
+# Design: Core + Fusion Reusable Workflows
+
+## Goal
+
+Update `dbt-package-testing` to provide two reusable GitHub Actions workflows:
+
+- `run_tox.yml` — runs dbt Core integration tests (existing, updated)
+- `run_tox_fusion.yml` — runs dbt Fusion integration tests (new)
+
+Both support optional `pull_request_target` usage with GitHub Environment gating for fork PRs.
+
+## Shared Interface
+
+Both workflows accept these new inputs:
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `adapters` | string | no | `""` | Comma-separated adapter list. Falls back to reading `supported_adapters.env` from the calling repo. |
+| `environment` | string | no | `""` | GitHub Environment name for job protection (e.g. `cloud-tests`). |
+| `ref` | string | no | `""` | Git ref to checkout. Required for `pull_request_target` callers — pass `github.event.pull_request.head.sha`. |
+
+All existing adapter credential inputs and secrets remain unchanged for backwards compatibility.
+
+## Adapter Resolution
+
+Both workflows use the same logic to determine which adapters to test:
+
+```yaml
+- name: "Get list of supported adapters"
+  run: |
+    if [ -n "$INPUT_ADAPTERS" ]; then
+      echo "test_adapters=$INPUT_ADAPTERS" >> $GITHUB_OUTPUT
+    else
+      source supported_adapters.env
+      echo "test_adapters=$SUPPORTED_ADAPTERS" >> $GITHUB_OUTPUT
+    fi
+  env:
+    INPUT_ADAPTERS: ${{ inputs.adapters }}
+```
+
+## Changes to `run_tox.yml` (Core)
+
+1. Add `adapters`, `environment`, and `ref` inputs.
+2. Update `determine-supported-adapters` to prefer `adapters` input over `supported_adapters.env`.
+3. Add `environment: ${{ inputs.environment }}` to the `run-tests` job.
+4. Update checkout step: `ref: ${{ inputs.ref || github.ref }}`.
+
+## New `run_tox_fusion.yml`
+
+Same structure as `run_tox.yml` with these differences:
+
+- **Install step**: installs Fusion via `curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh` instead of `pip install dbt-<adapter>`.
+- **Tox env**: runs `tox -e dbt_integration_fusion_${{ matrix.adapter }}` instead of `tox -e dbt_integration_${{ matrix.adapter }}`.
+- **No postgres service container**: Fusion does not support postgres.
+- **No adapter pip install**: Fusion bundles adapter support.
+
+## Caller Example
+
+A calling repo (e.g. `dbt-project-evaluator`) would have a single CI workflow:
+
+```yaml
+name: Package Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+  workflow_dispatch:
+
+jobs:
+  core-tests:
+    uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@main
+    with:
+      adapters: "snowflake,bigquery,redshift,databricks"
+      environment: >-
+        ${{ github.event_name == 'pull_request_target'
+            && github.event.pull_request.head.repo.full_name != github.repository
+            && 'cloud-tests' || '' }}
+      ref: ${{ github.event.pull_request.head.sha || '' }}
+      SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
+      # ... other adapter vars ...
+    secrets:
+      SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+      # ... other secrets ...
+
+  fusion-tests:
+    uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox_fusion.yml@main
+    with:
+      adapters: "snowflake"
+      environment: >-
+        ${{ github.event_name == 'pull_request_target'
+            && github.event.pull_request.head.repo.full_name != github.repository
+            && 'cloud-tests' || '' }}
+      ref: ${{ github.event.pull_request.head.sha || '' }}
+      SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
+      # ... other adapter vars ...
+    secrets:
+      SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+      # ... other secrets ...
+```
+
+## Caller Requirements
+
+- `tox.ini` with `[testenv:dbt_integration_<adapter>]` sections for Core
+- `tox.ini` with `[testenv:dbt_integration_fusion_<adapter>]` sections for Fusion
+- Either `supported_adapters.env` or pass `adapters` input explicitly
+- A GitHub Environment (e.g. `cloud-tests`) configured with required reviewers if using `pull_request_target` with fork protection


### PR DESCRIPTION
## Summary

- **New `run_tox_fusion.yml` reusable workflow** for testing dbt packages against the dbt Fusion engine. Installs Fusion via the official install script and runs `tox -e dbt_integration_fusion_<adapter>` for each adapter in the matrix.
- **`pull_request_target` support** for both workflows via new `environment` and `ref` inputs. This fixes a long-standing gap where open-source repos using this action couldn't test incoming community PRs from forks — fork PRs don't have access to repository secrets under `pull_request`, so CI would always fail. With `pull_request_target` + GitHub Environment gating, maintainers can approve workflow runs for fork PRs before secrets are exposed.
- **New `adapters` input** to explicitly specify which adapters to test, instead of relying on a `supported_adapters.env` file (which is still supported as a fallback).
- **Updated README** with full setup documentation: integration test project structure, `profiles.yml` setup, `tox.ini` conventions, GitHub secrets/variables configuration, caller workflow examples, and fork PR protection.
- **Updated `ci.yml` example** demonstrating both Core and Fusion workflow calls with `pull_request_target` and environment gating.

This will be released as **v2.0.0** (breaking change: new workflow interface with additional inputs).